### PR TITLE
Fix strategy to read version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,30 @@
+import codecs
+import os.path
+
 from setuptools import setup, find_packages
 from iracema import __version__
+
+
+def read(rel_path):
+    here = os.path.abspath(os.path.dirname(__file__))
+    with codecs.open(os.path.join(here, rel_path), 'r') as fp:
+        return fp.read()
+
+def get_version(rel_path):
+    for line in read(rel_path).splitlines():
+        if line.startswith('__version__'):
+            delim = '"' if '"' in line else "'"
+            return line.split(delim)[1]
+    else:
+        raise RuntimeError("Unable to find version string.")
 
 with open("README.rst", "r") as fh:
     long_description = fh.read()
 
 setup(
     name='iracema',
-    version=__version__,
     url='http://github.com/cegeme/iracema',
+    version=__version__,
     author='Tairone Magalhães',
     author_email='taironemagalhaes@gmail.com',
     description='Audio Content Analysis for Research on Musical Expressiveness and Individuality',


### PR DESCRIPTION
When attempting to read the `__version__` variable from `iracema.__init__.py` during packaging, setuptools is throwing an error. This is a workaround to try to fix this issue.