### PR TITLE
Remove version import from setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,6 @@ import codecs
 import os.path
 
 from setuptools import setup, find_packages
-from iracema import __version__
-
 
 def read(rel_path):
     here = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
Second attempt to fix packaging error after setup.py started to read the package version dynamically.