### PR TITLE
Refactor imports

### DIFF
--- a/iracema/__init__.py
+++ b/iracema/__init__.py
@@ -2,8 +2,8 @@
 iracema is a python package aimed at the extraction of expressive music
 information from audio signals
 """
-from .timeseries import TimeSeries, Audio
-from .segment import Segment, SegmentList
+from iracema.timeseries import TimeSeries, Audio
+from iracema.segment import Segment, SegmentList
 
 import iracema.features
 import iracema.harmonics

--- a/iracema/features.py
+++ b/iracema/features.py
@@ -33,9 +33,9 @@ References
 import numpy as np
 from scipy.stats import gmean  # pylint: disable=import-error
 
-from .aggregation import (aggregate_features, aggregate_sucessive_samples,
+from iracema.aggregation import (aggregate_features, aggregate_sucessive_samples,
                           sliding_window)
-from .util.dsp import hwr
+from iracema.util.dsp import hwr
 
 
 def peak_envelope(time_series, window_size, hop_size):

--- a/iracema/harmonics.py
+++ b/iracema/harmonics.py
@@ -5,8 +5,8 @@ monophonic audio.
 
 import numpy as np
 
-from .timeseries import TimeSeries
-from .util.dsp import local_peaks, n_highest_peaks
+from iracema.timeseries import TimeSeries
+from iracema.util.dsp import local_peaks, n_highest_peaks
 
 
 def extract(fft,

--- a/iracema/pitch.py
+++ b/iracema/pitch.py
@@ -16,9 +16,9 @@ References
 import numpy as np
 import scipy.signal as sig
 
-from .timeseries import TimeSeries
-from .util.dsp import local_peaks, n_highest_peaks, decimate_mean
-from .aggregation import aggregate_features
+from iracema.timeseries import TimeSeries
+from iracema.util.dsp import local_peaks, n_highest_peaks, decimate_mean
+from iracema.aggregation import aggregate_features
 
 
 def hps(fft_time_series, minf0, maxf0, n_downsampling=16,

--- a/iracema/plot.py
+++ b/iracema/plot.py
@@ -6,10 +6,11 @@ import warnings
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
+
 from matplotlib.widgets import MultiCursor  # pylint: disable=import-error
 from mpl_toolkits.mplot3d import Axes3D  # pylint: disable=import-error
 
-import iracema.features as features
+from iracema.features import rms as rms_, peak_envelope as peak_envelope_
 
 
 def plot_spectrogram(fft,
@@ -336,9 +337,9 @@ def add_waveform_trio_to_axes(axes,
     ``peak_evelope``. This method adds them to ``axes``.
     """
     window_size, hop_size = 2048, 512
-    rms = rms or features.rms(audio, window_size, hop_size)
+    rms = rms or rms_(audio, window_size, hop_size)
     peak_envelope =\
-        peak_envelope or features.peak_envelope(audio, window_size,
+        peak_envelope or peak_envelope_(audio, window_size,
                                                    hop_size)
     # adding the curves
     add_curve_to_axes(axes, audio, linewidth=0.1, alpha=0.9)

--- a/iracema/segment.py
+++ b/iracema/segment.py
@@ -3,7 +3,7 @@ Contain classes used to extract and manipulate segments.
 """
 import numpy as np
 
-from .util import conversion
+from iracema.util import conversion
 
 
 class Segment:

--- a/iracema/segmentation.py
+++ b/iracema/segmentation.py
@@ -8,8 +8,8 @@ import scipy.signal as sig
 import iracema.features
 import iracema.pitch
 import iracema.segment
-from iracema.aggregation import aggregate_sucessive_samples
 
+from iracema.aggregation import aggregate_sucessive_samples
 from iracema.plot import plot_waveform_trio_features_and_points
 
 

--- a/iracema/timeseries.py
+++ b/iracema/timeseries.py
@@ -9,10 +9,10 @@ import matplotlib.pyplot as plt
 import numpy as np
 import resampy
 
-from .segment import Segment
-from .util import conversion
-from .io.audiofile import read
-from .io import player
+from iracema.segment import Segment
+from iracema.util import conversion
+from iracema.io.audiofile import read
+from iracema.io import player
 
 
 class TimeSeries:


### PR DESCRIPTION
- Substitute relative imports by absolute ones.
- Fix an import in module `iracema.io.player` that could potentially cause a circular dependency error.
- Fix a sampling rate bug in the click sounds.