### PR TITLE
Minor Fix documentation: git clone option concerning submodules

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,7 +74,7 @@ To contribute with the development of iracema, clone the repository from github:
 
 .. code-block:: bash
 
-   git clone --recursive https://github.com/cegeme/iracema.git
+   git clone --recurse-submodules https://github.com/cegeme/iracema.git
 
 
 The command shown above will also clone some example audio files. 


### PR DESCRIPTION
The current option would entail running additional commands.
The shorthand option was added (details below).

Man page:

--recurse-submodules[=<pathspec]
    After the clone is created, initialize and clone submodules within
    based on the provided pathspec.
    [...]
    This is equivalent to running git submodule update --init
    --recursive <pathspec> immediately after the clone is finished.